### PR TITLE
Update bauble rev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 bauble = ["dep:bauble"]
 
 [dependencies]
-bauble = {git = "https://github.com/Cakefish/bauble.git", optional = true}
+bauble = {git = "https://github.com/Cakefish/bauble.git", rev="017f2d271584b34b7910f203458e4d493d1f9ec1", optional = true}
 thiserror = "^1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 bauble = ["dep:bauble"]
 
 [dependencies]
-bauble = {git = "https://github.com/Cakefish/bauble.git", rev = "697ee23a3b58e43f8deca6190ceec7b38c5e94d3", optional = true}
+bauble = {git = "https://github.com/Cakefish/bauble.git", optional = true}
 thiserror = "^1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 bauble = ["dep:bauble"]
 
 [dependencies]
-bauble = {git = "https://github.com/Cakefish/bauble.git", rev="017f2d271584b34b7910f203458e4d493d1f9ec1", optional = true}
+bauble = {git = "https://github.com/Cakefish/bauble.git", rev="e70b30845ad68ccf7ac33b31f6257a70d1581a43", optional = true}
 thiserror = "^1.0"


### PR DESCRIPTION
I wonder if there's some way we can get this to just use the same bauble that's used at the point this is used?

This should wait on https://github.com/Cakefish/bauble/pull/21